### PR TITLE
Add ALPN Protocols Client & Server config option

### DIFF
--- a/durian/src/packet.rs
+++ b/durian/src/packet.rs
@@ -260,6 +260,15 @@ pub struct ServerConfig {
     /// __WARNING: If a peer or its network path malfunctions or acts maliciously, an infinite idle timeout can result
     /// in permanently hung futures!__
     pub idle_timeout: Option<Duration>,
+
+    /// Protocols to send to server if applicable.
+    ///
+    /// ## Example:
+    ///
+    /// ```
+    /// config.with_alpn_protocols(&[b"hq-29"]);
+    /// ```
+    pub alpn_protocols: Option<Vec<Vec<u8>>>,
 }
 
 impl ServerConfig {
@@ -279,6 +288,7 @@ impl ServerConfig {
             num_send_streams,
             keep_alive_interval: None,
             idle_timeout: None,
+            alpn_protocols: None
         }
     }
 
@@ -297,6 +307,7 @@ impl ServerConfig {
             num_send_streams,
             keep_alive_interval: None,
             idle_timeout: None,
+            alpn_protocols: None
         }
     }
 
@@ -316,6 +327,7 @@ impl ServerConfig {
             num_send_streams,
             keep_alive_interval: None,
             idle_timeout: None,
+            alpn_protocols: None
         }
     }
 
@@ -328,6 +340,12 @@ impl ServerConfig {
     /// Set the idle timeout
     pub fn with_idle_timeout(&mut self, duration: Duration) -> &mut Self {
         self.idle_timeout = Some(duration);
+        self
+    }
+
+    /// Set the ALPN protocols
+    pub fn with_alpn_protocols(&mut self, protocols: &[&[u8]]) -> &mut Self {
+        self.alpn_protocols = Some(protocols.iter().map(|&x| x.into()).collect());
         self
     }
 }
@@ -532,6 +550,7 @@ impl PacketManager {
             server_config.addr.parse()?,
             server_config.keep_alive_interval,
             server_config.idle_timeout,
+            server_config.alpn_protocols
         )?;
         let num_receive_streams = server_config.num_receive_streams;
         let num_send_streams = server_config.num_send_streams;

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -52,6 +52,7 @@ impl PacketBuilder<Identifier> for IdentifierPacketBuilder {
 fn sync_example() {
     let client_addr = "127.0.0.1:5001";
     let server_addr = "127.0.0.1:5000";
+    let alpn_protocols = &[b"hq-29"];
 
     // Server example
     let mut server_manager = PacketManager::new();
@@ -67,7 +68,8 @@ fn sync_example() {
     // clients, as well as the total number of expected clients (or None if server can accept any
     // number of clients).  A thread will be spun up to wait for extra clients beyond the number
     // to block on.
-    let server_config = ServerConfig::new(server_addr, 0, Some(1), 3, 2);
+    let mut server_config = ServerConfig::new(server_addr, 0, Some(1), 3, 2);
+    server_config.with_alpn_protocols(alpn_protocols);
     server_manager.init_server(server_config).unwrap();
 
     // Client example
@@ -83,7 +85,8 @@ fn sync_example() {
     // connection, and validates against the number of registered packets.
     // Since this is the client-side, this is a blocking call that waits until the connection is
     // established.
-    let client_config = ClientConfig::new(client_addr, server_addr, 2, 3);
+    let mut client_config = ClientConfig::new(client_addr, server_addr, 2, 3);
+    client_config.with_alpn_protocols(alpn_protocols);
     client_manager.init_client(client_config).unwrap();
 
     // Below we show different ways to send/receive packets

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -53,7 +53,6 @@ impl PacketBuilder<Identifier> for IdentifierPacketBuilder {
 fn sync_example() {
     let client_addr = "127.0.0.1:5001";
     let server_addr = "127.0.0.1:5000";
-    let alpn_protocols: &[&[u8]] = &[b"hq-29"];
 
     // Server example
     let mut server_manager = PacketManager::new();
@@ -70,7 +69,10 @@ fn sync_example() {
     // number of clients).  A thread will be spun up to wait for extra clients beyond the number
     // to block on.
     let mut server_config = ServerConfig::new(server_addr, 0, Some(1), 3, 2);
-    server_config.with_alpn_protocols(alpn_protocols);
+
+    // Here you can set various optional configurations
+    // server_config.with_alpn_protocols(&[b"hq-29"]);
+
     server_manager.init_server(server_config).unwrap();
 
     // Client example
@@ -87,7 +89,10 @@ fn sync_example() {
     // Since this is the client-side, this is a blocking call that waits until the connection is
     // established.
     let mut client_config = ClientConfig::new(client_addr, server_addr, 2, 3);
-    client_config.with_alpn_protocols(alpn_protocols);
+
+    // Here you can set various optional configurations
+    // client_config.with_alpn_protocols(&[b"hq-29"]);
+
     client_manager.init_client(client_config).unwrap();
 
     // Below we show different ways to send/receive packets

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,6 +1,6 @@
+use durian::{bincode_packet, BinPacket, ClientConfig, Packet, PacketBuilder, PacketManager, ServerConfig, UnitPacket};
 use durian::bytes::Bytes;
 use durian::serde::{Deserialize, Serialize};
-use durian::{bincode_packet, BinPacket, ClientConfig, Packet, PacketBuilder, PacketManager, ServerConfig, UnitPacket};
 use std::error::Error;
 
 // Using #[bincode_packet]
@@ -41,6 +41,7 @@ impl Packet for Identifier {
 }
 
 struct IdentifierPacketBuilder;
+
 impl PacketBuilder<Identifier> for IdentifierPacketBuilder {
     fn read(&self, bytes: Bytes) -> Result<Identifier, Box<dyn Error>> {
         let name = std::str::from_utf8(&bytes)?.to_string();
@@ -52,7 +53,7 @@ impl PacketBuilder<Identifier> for IdentifierPacketBuilder {
 fn sync_example() {
     let client_addr = "127.0.0.1:5001";
     let server_addr = "127.0.0.1:5000";
-    let alpn_protocols = &[b"hq-29"];
+    let alpn_protocols: &[&[u8]] = &[b"hq-29"];
 
     // Server example
     let mut server_manager = PacketManager::new();


### PR DESCRIPTION
Adds a client & server config option to pass in ALPN protocols. It is empty by default.

This includes a new `with_alpn_protocols()` method for `ClientConfig` and `ServerConfig`.